### PR TITLE
[tests] FIX: Force gcc to link gtest with -pthread

### DIFF
--- a/src/Caribou/Algebra/test/CMakeLists.txt
+++ b/src/Caribou/Algebra/test/CMakeLists.txt
@@ -8,6 +8,9 @@ set(SOURCE_FILES
 enable_testing()
 find_package(GTest REQUIRED)
 
+# Required by old versions of gtest (such as defaults for ubuntu 16.04)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${GTEST_BOTH_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} Caribou.Algebra)

--- a/src/Caribou/Geometry/test/CMakeLists.txt
+++ b/src/Caribou/Geometry/test/CMakeLists.txt
@@ -8,6 +8,9 @@ set(SOURCE_FILES
 enable_testing()
 find_package(GTest REQUIRED)
 
+# Required by old versions of gtest (such as defaults for ubuntu 16.04)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${GTEST_BOTH_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} Caribou.Algebra)

--- a/src/Caribou/Topology/test/CMakeLists.txt
+++ b/src/Caribou/Topology/test/CMakeLists.txt
@@ -8,6 +8,9 @@ set(SOURCE_FILES
 enable_testing()
 find_package(GTest REQUIRED)
 
+# Required by old versions of gtest (such as defaults for ubuntu 16.04)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${GTEST_BOTH_LIBRARIES} Caribou.Topology)
 


### PR DESCRIPTION
On GCC 5.4, tests show linking errors with pthread. forcing -pthread in the CXX_FLAGS seems to solve the problem