### PR TITLE
[SofaCaribou] Import SOFA's python bindings before SofaCaribou

### DIFF
--- a/src/SofaCaribou/Python/__init__.py
+++ b/src/SofaCaribou/Python/__init__.py
@@ -1,1 +1,6 @@
-from .${MODULENAME}  import *
+# We first import Sofa.Core since without this, bindings will be unable
+# to have sofa::core::objectmodel::BaseObject as a base class
+from Sofa import Core
+
+# Then, we import the actual bindings
+from .${MODULENAME} import *


### PR DESCRIPTION
When importing SofaCaribou in a python interpreter, the classes inheriting BaseObject would fail if the bindings of Sofa.Core were not (yet) imported. Hence we had to import Sofa.Core before SofaCaribou.

This PR automatically import Sofa.Core in the interpreter before the python bindings of SofaCaribou. 