### PR TITLE
[Topology] Refactor the way Mesh stores its nodes.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           export DYLD_LIBRARY_PATH=$SOFA_ROOT/lib:$LD_LIBRARY_PATH
           export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/caribou/lib/python3/site-packages
-          python caribou/bin/pytest/Caribou.Geometry.Test.py
+          python caribou/bin/pytest/Caribou_Geometry_Test.py
 
       - name: Caribou.Topology.Test
         if: ${{ always() }}
@@ -149,7 +149,7 @@ jobs:
         run: |
           export DYLD_LIBRARY_PATH=$SOFA_ROOT/lib:$LD_LIBRARY_PATH
           export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/caribou/lib/python3/site-packages
-          python caribou/bin/pytest/Caribou.Topology.Test.py
+          python caribou/bin/pytest/Caribou_Topology_Test.py
 
       - name: Caribou.Mechanics.Test
         if: ${{ always() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$SOFA_ROOT/lib:$LD_LIBRARY_PATH
           export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/caribou/lib/python3/site-packages
-          python3 caribou/bin/pytest/Caribou.Geometry.Test.py
+          python3 caribou/bin/pytest/Caribou_Geometry_Test.py
 
       - name: Caribou.Topology.Test
         if: ${{ always() }}
@@ -164,7 +164,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$SOFA_ROOT/lib:$LD_LIBRARY_PATH
           export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/caribou/lib/python3/site-packages
-          python3 caribou/bin/pytest/Caribou.Topology.Test.py
+          python3 caribou/bin/pytest/Caribou_Topology_Test.py
 
       - name: Caribou.Mechanics.Test
         if: ${{ always() }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,18 @@ set (CARIBOU_VERSION ${PROJECT_VERSION})
 
 ## Default build type
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+## Change default install prefix
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)
 endif()
 
 # Detect if Caribou is a subproject of SOFA
 if ("${CMAKE_PROJECT_NAME}" STREQUAL "Sofa")
     set(CARIBOU_COMPILED_AS_SOFA_SUBPROJECT 1)
     message(STATUS "${PROJECT_NAME} is compiled as a subproject to SOFA.")
-elseif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX "install")
 endif ()
 
 # If the plugin is compiled within SOFA, add an option to deactivate it, in which case the remaining
@@ -150,11 +153,6 @@ find_package(VTK COMPONENTS ${CARIBOU_VTK_MODULES} QUIET)
 CMAKE_DEPENDENT_OPTION(CARIBOU_WITH_VTK "Compile the plugin with VTK support." ON "VTK_FOUND" OFF)
 if (CARIBOU_WITH_VTK)
     message(STATUS "Caribou with VTK support\n\tVersion: ${VTK_VERSION}")
-endif()
-
-## Change default install prefix
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)
 endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/bindings/Geometry/CMakeLists.txt
+++ b/bindings/Geometry/CMakeLists.txt
@@ -5,7 +5,7 @@ set(PYTHON_FILES
 )
 
 set(PYTHON_TEST_FILES
-    pytest/Caribou.Geometry.Test.py
+    pytest/Caribou_Geometry_Test.py
 )
 
 set(HEADER_FILES

--- a/bindings/Geometry/pytest/Caribou_Geometry_Test.py
+++ b/bindings/Geometry/pytest/Caribou_Geometry_Test.py
@@ -3,9 +3,12 @@
 import sys
 import unittest
 import numpy as np
+from pathlib import Path
 
-sys.path.insert(0, "@CARIBOU_PYTHON_LIB_PATH@")
-
+current_dir = Path(__file__).parent
+site_packages_dir = (current_dir / '..' / '..' / 'lib' / 'python3' / 'site-packages').resolve()
+sys.path.insert(0, str(site_packages_dir))
+print(f'Adding {site_packages_dir} to sys.path')
 import Caribou
 from Caribou.Geometry import Segment
 from Caribou.Geometry import Quad

--- a/bindings/Topology/CMakeLists.txt
+++ b/bindings/Topology/CMakeLists.txt
@@ -5,7 +5,7 @@ set(PYTHON_FILES
 )
 
 set(PYTHON_TEST_FILES
-    pytest/Caribou.Topology.Test.py
+    pytest/Caribou_Topology_Test.py
 )
 
 set(HEADER_FILES

--- a/bindings/Topology/Mesh.cpp
+++ b/bindings/Topology/Mesh.cpp
@@ -5,15 +5,7 @@
 
 #include <Caribou/constants.h>
 #include <Caribou/Topology/Mesh.h>
-#include <Caribou/Geometry/Hexahedron.h>
-#include <Caribou/Geometry/Quad.h>
-#include <Caribou/Geometry/Segment.h>
-#include <Caribou/Geometry/Triangle.h>
-#include <Caribou/Geometry/Tetrahedron.h>
-
-#include <Caribou/Bindings/Caribou.h>
 #include <Caribou/Bindings/Topology/Domain.h>
-
 
 namespace py = pybind11;
 
@@ -21,8 +13,8 @@ namespace caribou::topology::bindings {
 
 template <UNSIGNED_INTEGER_TYPE Dim, typename MatrixType>
 void declare_mesh(py::module & m) {
-    std::string name = "Mesh"+std::to_string(Dim)+"D"+typeid(MatrixType).name();
-    using M = Mesh<Dim, MatrixType>;
+    using M = Mesh<Dim, EigenNodesHolder<MatrixType>>;
+    std::string name = typeid(M).name();
     py::class_<M> c(m, name.c_str());
 
     c.def("dimension", &M::dimension);
@@ -53,7 +45,6 @@ void declare_mesh(py::module & m) {
 
 template <UNSIGNED_INTEGER_TYPE Dim>
 void declare_mesh(py::module &m) {
-//    todo(jnbrunet2000@gmail.com): Uncomment once we allow a no_copy options for the matrices (pass by ref of a np.array)
 //    declare_mesh<Dim, Eigen::Matrix<float, Eigen::Dynamic, Dim, (Dim>1?Eigen::RowMajor:Eigen::ColMajor)>>(m);
     declare_mesh<Dim, Eigen::Matrix<double, Eigen::Dynamic, Dim, (Dim>1?Eigen::RowMajor:Eigen::ColMajor)>>(m);
 }

--- a/bindings/Topology/pytest/Caribou_Topology_Test.py
+++ b/bindings/Topology/pytest/Caribou_Topology_Test.py
@@ -4,14 +4,16 @@ import sys, os
 import unittest
 import numpy as np
 import meshio
+from pathlib import Path
 
-sys.path.insert(0, "@CARIBOU_PYTHON_LIB_PATH@")
-
+current_dir = Path(__file__).parent
+site_packages_dir = (current_dir / '..' / '..' / 'lib' / 'python3' / 'site-packages').resolve()
+sys.path.insert(0, str(site_packages_dir))
+print(f'Adding {site_packages_dir} to sys.path')
 import Caribou
 from Caribou.Topology import Mesh
 from Caribou.Topology import Grid3D
 from Caribou.Geometry import Segment
-from Caribou.Geometry import Quad
 from Caribou.Geometry import Triangle
 from Caribou.Geometry import Tetrahedron
 from Caribou.Geometry import Hexahedron
@@ -290,7 +292,7 @@ class TestGrid(unittest.TestCase):
             self.assertEqual(i, g.node_index_at(g.node_coordinates_at(i)))
 
         # Edge queries
-        # First slice (2D grid) 
+        # First slice (2D grid)
         self.assertEqual(g.number_of_edges(), 3*12 + 2*9)
         self.assertMatrixEqual(g.edge(0), [0, 1])
         self.assertMatrixEqual(g.edge(0), [0, 1])

--- a/src/Topology/BaseDomain.h
+++ b/src/Topology/BaseDomain.h
@@ -32,5 +32,12 @@ namespace caribou::topology {
          * Get the number of elements contained in the domain.
          */
         [[nodiscard]] virtual auto number_of_elements() const -> UNSIGNED_INTEGER_TYPE= 0;
+
+        /**
+         * Clone the domain into a new instance.
+         * @return A pointer to the newly created instance.
+         * @note The caller becomes owner of the pointer and is therefore responsible to release its memory.
+         */
+        [[nodiscard]] virtual BaseDomain * clone() const = 0;
     };
 }

--- a/src/Topology/Domain.h
+++ b/src/Topology/Domain.h
@@ -114,6 +114,10 @@ namespace caribou::topology {
         /*! Destructor */
         ~Domain() final = default;
 
+        BaseDomain * clone() const override {
+            return new Domain(*this); // Will call the copy constructor
+        }
+
         /*!
          * \copydoc caribou::topology::BaseDomain::canonical_dimension
          */


### PR DESCRIPTION
This PR is a first step to implement the creation of meshes where the nodal position vector is allocated externally, or managed differently than our default implementation. One would have to simply define a new NodeContainer type and pass it as a template argument to the Mesh class.