### PR TITLE
[Topology] Fix intersection test between an hexahedron and a triangle

### DIFF
--- a/src/Caribou/Geometry/BaseHexahedron.h
+++ b/src/Caribou/Geometry/BaseHexahedron.h
@@ -3,6 +3,7 @@
 #include <Caribou/config.h>
 #include <Caribou/constants.h>
 #include <Caribou/Geometry/Element.h>
+#include <Caribou/Geometry/Triangle.h>
 #include <Eigen/Core>
 
 
@@ -138,6 +139,33 @@ struct BaseHexahedron : public Element<Derived> {
         return m;
     }
 
+    /**
+     * Test if the cube intersects the given 3D segment (in world coordinates)
+     *
+     * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
+     */
+    [[nodiscard]]
+    inline auto intersects(const Segment<_3D, Linear> & segment, const FLOATING_POINT_TYPE eps=0) const -> bool {
+        return intersects_local_segment(self().local_coordinates(segment.node(0)), self().local_coordinates(segment.node(1)), eps);
+    }
+
+    /**
+     * Test if the cube intersects the given 3D triangle (in world coordinates)
+     *
+     * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
+     */
+    [[nodiscard]]
+    inline auto intersects(const Triangle<_3D, Linear> & t, const FLOATING_POINT_TYPE eps=0) const -> bool {
+        LocalCoordinates nodes[3];
+        for (UNSIGNED_INTEGER_TYPE i = 0; i < 3; ++i) {
+            nodes[i] = self().local_coordinates(t.node(i));
+        }
+
+        auto normal = (nodes[1] - nodes[2]).cross(nodes[2] - nodes[0]).eval().normalized();
+
+        return intersects_local_polygon<3>(nodes, normal, eps);
+    }
+
 private:
     // Implementations
     friend struct Element<Derived>;
@@ -157,6 +185,26 @@ private:
                IN_CLOSED_INTERVAL(-1-eps, w, 1+eps);
     }
 
+    /**
+    * Test if the cube intersects the given 3D segment (in the hexahedron's local coordinates).
+    *
+    * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
+    */
+    [[nodiscard]]
+    inline auto intersects_local_segment(LocalCoordinates v0, LocalCoordinates v1, const FLOATING_POINT_TYPE & eps) const -> bool;
+
+    /**
+     * Test if the cube intersects the given 3D polygon (in world coordinates).
+     *
+     * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
+     * @tparam NNodes Number of nodes in the polygon
+     * @param nodes The nodes of the polygon
+     * @param polynormal Vector perpendicular to the polygon.  It need not be of unit length.
+     * @return True if the polygon intersects the cube, false otherwise.
+     */
+    template <int NNodes>
+    inline auto intersects_local_polygon(const LocalCoordinates nodes[NNodes], const Vector<3> & polynormal, const FLOATING_POINT_TYPE & eps) const -> bool;
+
     auto self() -> Derived& { return *static_cast<Derived*>(this); }
     auto self() const -> const Derived& { return *static_cast<const Derived*>(this); }
 
@@ -175,5 +223,113 @@ private:
 protected:
     Matrix<NumberOfNodesAtCompileTime, Dimension> p_nodes;
 };
+
+template<typename Derived>
+auto BaseHexahedron<Derived>::intersects_local_segment(LocalCoordinates v0, LocalCoordinates v1, const FLOATING_POINT_TYPE & eps) const -> bool
+{
+    const auto edge = (v1 - v0);
+    INTEGER_TYPE edge_signs[3];
+
+    for (UNSIGNED_INTEGER_TYPE i = 0; i < 3; ++i) {
+        edge_signs[i] = (edge[i] < 0) ? -1 : 1;
+    }
+
+    for (UNSIGNED_INTEGER_TYPE i = 0; i < 3; ++i) {
+
+        if (v0[i] * edge_signs[i] >  1+eps) return false;
+        if (v1[i] * edge_signs[i] < -1-eps) return false;
+    }
+
+
+    for (UNSIGNED_INTEGER_TYPE i = 0; i < 3; ++i) {
+        FLOATING_POINT_TYPE rhomb_normal_dot_v0, rhomb_normal_dot_cubedge;
+
+        const UNSIGNED_INTEGER_TYPE iplus1 = (i + 1) % 3;
+        const UNSIGNED_INTEGER_TYPE iplus2 = (i + 2) % 3;
+
+        rhomb_normal_dot_v0 = edge[iplus2] * v0[iplus1] -
+                              edge[iplus1] * v0[iplus2];
+
+        rhomb_normal_dot_cubedge = edge[iplus2] * edge_signs[iplus1] +
+                                   edge[iplus1] * edge_signs[iplus2];
+
+        const auto r = (rhomb_normal_dot_v0*rhomb_normal_dot_v0) - (rhomb_normal_dot_cubedge*rhomb_normal_dot_cubedge);
+        if (r > eps)
+            return false;
+    }
+
+    return true;
+}
+
+#define seg_contains_point(a,b,x) (((b)>(x)) - ((a)>(x)))
+
+template<typename Derived>
+template <int NNodes>
+inline auto BaseHexahedron<Derived>::intersects_local_polygon(const LocalCoordinates nodes[NNodes], const Vector<3> & polynormal, const FLOATING_POINT_TYPE & eps) const -> bool {
+
+    // Check if any edges of the polygon intersect the hexa
+    for (UNSIGNED_INTEGER_TYPE i = 0; i < NNodes; ++i) {
+        const auto & p1 = nodes[i];
+        const auto & p2 = nodes[(i+1)%NNodes];
+        if (intersects_local_segment(p1, p2, eps))
+            return true;
+    }
+
+    // Check that if the polygon's plane intersect the cube diagonal that is the closest of being perpendicular to the
+    // plane of the polygon.
+    Vector<3> best_diagonal;
+    best_diagonal << (((polynormal[0]) < 0) ? -1 : 1),
+            (((polynormal[1]) < 0) ? -1 : 1),
+            (((polynormal[2]) < 0) ? -1 : 1);
+
+    // Check if the intersection point between the two planes lies inside the cube
+    const FLOATING_POINT_TYPE t = polynormal.dot(nodes[0]) / polynormal.dot(best_diagonal);
+    if (!IN_CLOSED_INTERVAL(-1-eps, t, 1+eps))
+        return false;
+
+    // Check if the intersection point between the two planes lies inside the polygon
+    LocalCoordinates p = best_diagonal * t;
+    const LocalCoordinates abspolynormal = polynormal.array().abs();
+    int zaxis, xaxis, yaxis;
+    if (abspolynormal[0] > abspolynormal[1])
+        zaxis = (abspolynormal[0] > abspolynormal[2]) ? 0 : 2;
+    else
+        zaxis = (abspolynormal[1] > abspolynormal[2]) ? 1 : 2;
+
+    if (polynormal[zaxis] < 0) {
+        xaxis = (zaxis+2)%3;
+        yaxis = (zaxis+1)%3;
+    }
+    else {
+        xaxis = (zaxis+1)%3;
+        yaxis = (zaxis+2)%3;
+    }
+
+    int count = 0;
+    for (UNSIGNED_INTEGER_TYPE i = 0; i < NNodes; ++i) {
+        const auto & p1 = nodes[i];
+        const auto & p2 = nodes[(i+1)%NNodes];
+
+        if (const int xdirection = seg_contains_point(p1[xaxis]-eps, p2[xaxis]+eps, p[xaxis]))
+        {
+            if (seg_contains_point(p1[yaxis]-eps, p2[yaxis]+eps, p[yaxis]))
+            {
+                if (xdirection * (p[xaxis]-p1[xaxis])*(p2[yaxis]-p1[yaxis]) <=
+                    xdirection * (p[yaxis]-p1[yaxis])*(p2[xaxis]-p1[xaxis]))
+                    count += xdirection;
+            }
+            else
+            {
+                if (p2[yaxis] <= p[yaxis])
+                    count += xdirection;
+            }
+        }
+
+    }
+
+    return (count != 0);
+}
+
+#undef seg_contains_point
 
 }

--- a/src/Caribou/Geometry/BaseRectangularHexahedron.h
+++ b/src/Caribou/Geometry/BaseRectangularHexahedron.h
@@ -99,7 +99,7 @@ struct BaseRectangularHexahedron : public Element<Derived> {
      * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
      */
     [[nodiscard]]
-    inline auto intersects(const Segment<_3D, Linear> & segment, const FLOATING_POINT_TYPE eps=EPSILON) const -> bool {
+    inline auto intersects(const Segment<_3D, Linear> & segment, const FLOATING_POINT_TYPE eps=0) const -> bool {
         return intersects_local_segment(local_coordinates(segment.node(0)), local_coordinates(segment.node(1)), eps);
     }
 
@@ -109,13 +109,15 @@ struct BaseRectangularHexahedron : public Element<Derived> {
      * @note  based on polygon_intersects_cube by Don Hatch (January 1994)
      */
     [[nodiscard]]
-    inline auto intersects(const Triangle<_3D, Linear> & t, const FLOATING_POINT_TYPE eps=1e-10) const -> bool {
+    inline auto intersects(const Triangle<_3D, Linear> & t, const FLOATING_POINT_TYPE eps=0) const -> bool {
         LocalCoordinates nodes[3];
         for (UNSIGNED_INTEGER_TYPE i = 0; i < 3; ++i) {
-            nodes[i] = local_coordinates(t.node(i));
+            nodes[i] = self().local_coordinates(t.node(i));
         }
 
-        return intersects_local_polygon<3>(nodes, t.normal(), eps);
+        auto normal = (nodes[1] - nodes[2]).cross(nodes[2] - nodes[0]).eval().normalized();
+
+        return intersects_local_polygon<3>(nodes, normal, eps);
     }
 
 private:

--- a/src/SofaCaribou/Topology/FictitiousGrid.cpp
+++ b/src/SofaCaribou/Topology/FictitiousGrid.cpp
@@ -3,11 +3,6 @@
 
 DISABLE_ALL_WARNINGS_BEGIN
 #include <sofa/core/ObjectFactory.h>
-#if (defined(SOFA_VERSION) && SOFA_VERSION < 201299)
-#include <sofa/helper/polygon_cube_intersection/polygon_cube_intersection.h>
-#else
-#include <SofaBaseTopology/polygon_cube_intersection/polygon_cube_intersection.h>
-#endif
 DISABLE_ALL_WARNINGS_END
 
 #ifdef CARIBOU_WITH_OPENMP
@@ -105,37 +100,12 @@ FictitiousGrid<Vec3Types>::tag_intersected_cells()
             for (const auto &cell_index : enclosing_cells) {
                 const auto e = p_grid->cell_at(cell_index);
                 TICK;
-
-//                    todo(jnbrunet2000@gmail.com): The test intersection does not work on some triangles
-//                        Failing test is in SofaCaribou/test/Topology/test_fictitiousgrid.cpp
-//                        meshes/deformed_liver_surface.stl
-//                        n = [37, 37, 37] and subdivision_level = 4
-//                const bool intersects = e.intersects(t);
-//                time_to_find_intersections += TOCK;
-//                if (intersects) {
-//                    p_cells_types[cell_index] = Type::Boundary;
-//                    p_triangles_of_cell[cell_index].emplace_back(triangle_index);
-//                }
-
-                const auto cube_diagonal = (e.node(6) - e.node(0)).eval();
-                const auto cube_center = (e.node(0) + 0.5*cube_diagonal).eval();
-
-                float points[3][3];
-
-                for (unsigned short w=0; w<3; ++w)
-                {
-                    points[0][w] = (float) ((nodes[0][w]-cube_center[w])/cube_diagonal[w]);
-                    points[1][w] = (float) ((nodes[1][w]-cube_center[w])/cube_diagonal[w]);
-                    points[2][w] = (float) ((nodes[2][w]-cube_center[w])/cube_diagonal[w]);
-                }
-
-                float normal[3];
-                sofa::helper::polygon_cube_intersection::get_polygon_normal(normal,3,points);
-                if (sofa::helper::polygon_cube_intersection::fast_polygon_intersects_cube(3,points,normal,0,0)) {
+                const bool intersects = e.intersects(t);
+                time_to_find_intersections += TOCK;
+                if (intersects) {
                     p_cells_types[cell_index] = Type::Boundary;
                     p_triangles_of_cell[cell_index].emplace_back(triangle_index);
                 }
-                time_to_find_intersections += TOCK;
             }
         }
     }
@@ -327,36 +297,11 @@ FictitiousGrid<Vec3Types>::subdivide_intersected_cells()
                         const Eigen::Map<const WorldCoordinates> p(&surface_positions[node_index][0]);
                         nodes[i] = p;
                     }
-//                    todo(jnbrunet2000@gmail.com): The test intersection does not work on some triangles
-//                        Failing test is in SofaCaribou/test/Topology/test_fictitiousgrid.cpp
-//                        meshes/deformed_liver_surface.stl
-//                        n = [15, 15, 15] and subdivision_level = 4
-//                    const caribou::geometry::Triangle<3> t(nodes[0], nodes[1], nodes[2]);
-//                    const bool intersects = e.intersects(t, 0);
-//
-//                    if (intersects) {
-//                        subdivide_the_cell = true;
-//                        type = Type::Boundary;
-//                        break;
-//                    }
 
-                    const auto cube_diagonal = (e.node(6) - e.node(0)).eval();
-                    const auto cube_center = (e.node(0) + 0.5*cube_diagonal).eval();
+                    const caribou::geometry::Triangle<3> t(nodes[0], nodes[1], nodes[2]);
+                    const bool intersects = e.intersects(t, 0);
 
-                    float points[3][3];
-
-                    for (unsigned short w=0; w<3; ++w)
-                    {
-                        points[0][w] = (float) ((nodes[0][w]-cube_center[w])/cube_diagonal[w]);
-                        points[1][w] = (float) ((nodes[1][w]-cube_center[w])/cube_diagonal[w]);
-                        points[2][w] = (float) ((nodes[2][w]-cube_center[w])/cube_diagonal[w]);
-                    }
-
-
-                    float normal[3];
-                    sofa::helper::polygon_cube_intersection::get_polygon_normal(normal,3,points);
-
-                    if (sofa::helper::polygon_cube_intersection::fast_polygon_intersects_cube(3,points,normal,0,0)) {
+                    if (intersects) {
                         subdivide_the_cell = true;
                         type = Type::Boundary;
                         break;

--- a/unittest/Caribou/Geometry/test_hexahedron.h
+++ b/unittest/Caribou/Geometry/test_hexahedron.h
@@ -12,6 +12,7 @@ TEST(Hexahedron, Linear) {
     using Hexahedron = caribou::geometry::Hexahedron<Linear>;
     using Tetrahedron = caribou::geometry::Tetrahedron<Linear>;
     using Quad = caribou::geometry::Quad<3, Linear>;
+    using Triangle = caribou::geometry::Triangle<3, Linear>;
     using Edge = caribou::geometry::Segment<3, Linear>;
     using LocalCoordinates = Hexahedron::LocalCoordinates;
     using WorldCoordinates = Hexahedron::WorldCoordinates;
@@ -145,6 +146,20 @@ TEST(Hexahedron, Linear) {
         }
 
         EXPECT_DOUBLE_EQ(numerical_solution_hexa, numerical_solution_tetras);
+
+        // Intersection with triangles (test taken from a failing scene)
+        {
+            Hexahedron h (
+                    WorldCoordinates(194.948, -111.776, -1547.85), WorldCoordinates(195.837, -111.776, -1547.85),
+                    WorldCoordinates(195.837, -110.461, -1547.85), WorldCoordinates(194.948, -110.461, -1547.85),
+                    WorldCoordinates(194.948, -111.776, -1546.86), WorldCoordinates(195.837, -111.776, -1546.86),
+                    WorldCoordinates(195.837, -110.461, -1546.86), WorldCoordinates(194.948, -110.461, -1546.86)
+            );
+
+            Triangle t (WorldCoordinates {195.402, -112.092, -1543.81}, WorldCoordinates {196.468, -108.742, -1546.42}, WorldCoordinates {193.869, -110.918, -1548.45});
+
+            ASSERT_TRUE(h.intersects(t, 0));
+        }
     }
 }
 


### PR DESCRIPTION
The intersection test between an hexahedron and a triangle wasn't taking into account the triangle's normal in the hexahedron local coordinates. Hence, the triangle nodes were correctly scaled into the hexa's local frame, but its normal was still referencing the triangle in global coordinates.