### PR TITLE
[CI] Publish linux artifacts

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,6 +27,8 @@ jobs:
           fetch-depth: 0
 
       - run: |
+          git config --global user.email "caribou@github.com"
+          git config --global user.name "Caribou Github"
           git fetch origin
           git rebase origin/master
 
@@ -189,3 +191,74 @@ jobs:
         run: |
             export PYTHONPATH=$PYTHONPATH:$CARIBOU_ROOT/lib/python3/site-packages:$SOFA_ROOT/plugins/SofaPython3/lib/python3/site-packages
             python3 $CARIBOU_ROOT/bin/pytest/SofaCaribou_Forcefield_HyperelasticForcefield.py
+
+
+  deploy:
+    name: Deploy ${{ matrix.sofa_version }}
+    needs: [test]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        sofa_version: [ v20.06.01, v20.12.03, v21.06.00, master ]
+    env:
+      SOFA_VERSION: ${{ matrix.sofa_version }}
+
+    steps:
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: caribou_${{ matrix.sofa_version }}
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y_%m_%d')"
+
+      - name: Get SOFA major/minor
+        id: sofa_version
+        run: |
+          if [ "$SOFA_VERSION" = "master" ]; then
+              echo "::set-output name=value::master"
+          else
+              echo "::set-output name=value::${SOFA_VERSION%.*}"
+          fi
+
+      - name: Create artifact directory
+        uses: appleboy/ssh-action@master
+        env:
+          ARTIFACT_TARGET: ${{ format('{0}/linux/{1}', secrets.ARTIFACT_TARGET, steps.sofa_version.outputs.value) }}
+        with:
+          host: ${{ secrets.ARTIFACT_HOST }}
+          username: ${{ secrets.ARTIFACT_USERNAME }}
+          key: ${{ secrets.ARTIFACT_KEY }}
+          port: ${{ secrets.ARTIFACT_PORT }}
+          envs: ARTIFACT_TARGET
+          script: mkdir -p $ARTIFACT_TARGET
+
+      - name: Deploy artifact
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.ARTIFACT_HOST }}
+          username: ${{ secrets.ARTIFACT_USERNAME }}
+          port: ${{ secrets.ARTIFACT_PORT }}
+          key: ${{ secrets.ARTIFACT_KEY }}
+          source: "SofaCaribou.tar.gz"
+          target: ${{ format('{0}/linux/{1}/SofaCaribou_{2}', secrets.ARTIFACT_TARGET, steps.sofa_version.outputs.value, steps.date.outputs.date) }}
+          debug: true
+
+      - name: Tag as latest
+        uses: appleboy/ssh-action@master
+        env:
+          ARTIFACT_TARGET: ${{ format('{0}/linux/{1}/SofaCaribou_{2}', secrets.ARTIFACT_TARGET, steps.sofa_version.outputs.value, steps.date.outputs.date) }}
+          ARTIFACT_LATEST: ${{ format('{0}/linux/{1}/SofaCaribou_latest.tar.gz', secrets.ARTIFACT_TARGET, steps.sofa_version.outputs.value) }}
+        with:
+          host: ${{ secrets.ARTIFACT_HOST }}
+          username: ${{ secrets.ARTIFACT_USERNAME }}
+          key: ${{ secrets.ARTIFACT_KEY }}
+          port: ${{ secrets.ARTIFACT_PORT }}
+          envs: ARTIFACT_TARGET,ARTIFACT_LATEST
+          script: |
+            mv $ARTIFACT_TARGET/SofaCaribou.tar.gz $ARTIFACT_TARGET.tar.gz
+            rm -rf $ARTIFACT_TARGET
+            rm -f $ARTIFACT_LATEST
+            ln -s $ARTIFACT_TARGET.tar.gz $ARTIFACT_LATEST

--- a/README.md
+++ b/README.md
@@ -12,7 +12,42 @@ The project is composed of two modules:
 1. **Caribou library** brings multiple geometric, linear analysis and topological tools that are designed to 
 be as independent as possible from external projects.
 2. **Sofa caribou library** is built on top of the **caribou library**, but brings new components to
-the SOFA project as a plugin. 
+the SOFA project as a plugin.
+
+### Quick installation
+
+You can get the latest binaries compatible with your SOFA version by following these links:
+
+| Sofa version | Linux                                                                                                      |MacOS | Windows |
+| ------------ | -----------------------------------------------------------------------------------------------------------|------|---------|
+| v20.06       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v20.06/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
+| v20.12       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v20.12/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
+| v21.06       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v21.06/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
+| master       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/master/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
+
+To install them, simply expand the archive content directly into the `plugins` directory of your 
+SOFA installation. For example, the following commands will install SOFA v21.06 and install Caribou plugin and its python bindings afterwards:
+
+```console
+$ # Set the environment variable that will contain the path to SOFA's installation
+$ export SOFA_ROOT=$PWD/SOFA_V21.06
+
+$ # Install SOFA V21.06 into SOFA_ROOT 
+$ # (SKIP THIS IF YOU ALREADY HAVE INSTALLED SOFA)
+$ curl --progress-bar --output sofa.zip -L "https://github.com/sofa-framework/sofa/releases/download/v21.06.00/SOFA_v21.06.00_Linux.zip"  && unzip -qq sofa.zip -d temp && mv temp/`ls temp` $SOFA_ROOT && rm -rf temp && rm -rf sofa.zip
+
+$ # Install Caribou into the SOFA_ROOT/plugins directory
+$ curl --progress-bar --output SofaCaribou.tar.gz -L "https://caribou.jnbrunet.com/artifacts/linux/v21.06/SofaCaribou_latest.tar.gz"
+$ tar zxf SofaCaribou.tar.gz --directory $SOFA_ROOT/plugins
+
+$ # Tell python where it should find SP3 and Caribou
+$ export PYTHONPATH="$SOFA_ROOT/plugins/SofaPython3/lib/python3/site-packages:$SOFA_ROOT/plugins/SofaCaribou/lib/python3/site-packages"
+
+$ # Test the installation
+$ python3.7 -c "import SofaRuntime;print(SofaRuntime);import SofaCaribou;print(SofaCaribou)"
+```
+
+### Documentation
 
 You can read the documentation for building and using Caribou at the following link:
 [https://caribou.readthedocs.io](https://caribou.readthedocs.io)


### PR DESCRIPTION
This PR will automatically publish the nightly built binaries to 

https://caribou.jnbrunet.com/artifacts/

For now, only Linux binaries are available. Hopefully, Windows and MacOS will follow at some point.

| Sofa version | Linux                                                                                                      |MacOS | Windows |
| ------------ | -----------------------------------------------------------------------------------------------------------|------|---------|
| v20.06       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v20.06/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
| v20.12       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v20.12/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
| v21.06       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/v21.06/SofaCaribou_latest.tar.gz) | N/A  | N/A     |
| master       | [SofaCaribou_latest.tar.gz](https://caribou.jnbrunet.com/artifacts/linux/master/SofaCaribou_latest.tar.gz) | N/A  | N/A     |

To install them, simply expand the archive content directly into the `plugins` directory of your 
SOFA installation. For example, the following commands will install SOFA v21.06 and install Caribou plugin and its python bindings afterwards:

```console
$ # Set the environment variable that will contain the path to SOFA's installation
$ export SOFA_ROOT=$PWD/SOFA_V21.06

$ # Install SOFA V21.06 into SOFA_ROOT 
$ # (SKIP THIS IF YOU ALREADY HAVE INSTALLED SOFA)
$ curl --progress-bar --output sofa.zip -L "https://github.com/sofa-framework/sofa/releases/download/v21.06.00/SOFA_v21.06.00_Linux.zip"  && unzip -qq sofa.zip -d temp && mv temp/`ls temp` $SOFA_ROOT && rm -rf temp && rm -rf sofa.zip

$ # Install Caribou into the SOFA_ROOT/plugins directory
$ curl --progress-bar --output SofaCaribou.tar.gz -L "https://caribou.jnbrunet.com/artifacts/linux/v21.06/SofaCaribou_latest.tar.gz"
$ tar zxf SofaCaribou.tar.gz --directory $SOFA_ROOT/plugins

$ # Tell python where it should find SP3 and Caribou
$ export PYTHONPATH="$SOFA_ROOT/plugins/SofaPython3/lib/python3/site-packages:$SOFA_ROOT/plugins/SofaCaribou/lib/python3/site-packages"

$ # Test the installation
$ python3.7 -c "import SofaRuntime;print(SofaRuntime);import SofaCaribou;print(SofaCaribou)"
```

CC @hugtalbot @fredroy 