### PR TITLE
Added -ldl flag when linking with MKL

### DIFF
--- a/src/SofaCaribou/CMakeLists.txt
+++ b/src/SofaCaribou/CMakeLists.txt
@@ -153,7 +153,7 @@ if (CARIBOU_WITH_MKL)
     target_compile_definitions(${PROJECT_NAME} PUBLIC CARIBOU_WITH_MKL)
     target_compile_definitions(${PROJECT_NAME} PRIVATE EIGEN_USE_MKL_ALL)
     target_include_directories(${PROJECT_NAME} PRIVATE ${MKL_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE  ${MKL_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME} PRIVATE  ${MKL_LIBRARIES} -ldl)
     target_link_options(${PROJECT_NAME} PRIVATE ${MKL_LINKER_FLAGS})
 endif()
 


### PR DESCRIPTION
Hello,

When compiling using MKL I ended up with undefined references to dl symbols  (addr, sym, open, close...).
Adding the -ldl flag solved the problem.

Have a nice day,

Odot Alban.