### PR TITLE
All members used in NewtonRaphsonSolver::solve are now protected. 

### DIFF
--- a/src/SofaCaribou/Ode/NewtonRaphsonSolver.h
+++ b/src/SofaCaribou/Ode/NewtonRaphsonSolver.h
@@ -164,6 +164,7 @@ private:
                                               sofa::core::MultiVecDerivId & v_id,
                                               sofa::core::MultiVecDerivId & dx_id) = 0;
 
+protected:
     /** Check that the linked linear solver is not null and that it implements the SofaCaribou::solver::LinearSolver interface */
     CARIBOU_API
     bool has_valid_linear_solver () const;


### PR DESCRIPTION
The NewtonRaphsonSolver private statement was blocking the inheritance by setting all variables used in the solve function as private. This statement forces code duplication by introducing a third class that copy-paste the code of both NewtonRaphsonSolver and StaticODESolver.
Simply, putting this statement allows inheriting from StaticODESolver and change the desired function.

Alban