### PR TITLE
Optimized addForce

### DIFF
--- a/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
+++ b/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
@@ -117,7 +117,7 @@ void HyperelasticForcefield<Element>::addForce(
     for (std::size_t element_id = 0; element_id < nb_elements; ++element_id) {
 
         // Fetch the node indices of the element
-        const auto& node_indices = this->topology()->domain()->element_indices(element_id);
+        const auto & node_indices = this->topology()->domain()->element_indices(element_id);
 
         // Fetch the initial and current positions of the element's nodes
         Matrix<NumberOfNodesPerElement, Dimension> current_nodes_position;
@@ -138,18 +138,18 @@ void HyperelasticForcefield<Element>::addForce(
             const auto & w = gauss_node.weight;
 
             // Deformation tensor at gauss node
-            const Mat33& F = current_nodes_position.transpose()*dN_dx;
-            const auto& J = F.determinant();
+            const Mat33 & F = current_nodes_position.transpose()*dN_dx;
+            const auto & J = F.determinant();
 
             // Right Cauchy-Green strain tensor at gauss node
-            const Mat33& C = F.transpose() * F;
+            const Mat33 & C = F.transpose() * F;
 
             // Second Piola-Kirchhoff stress tensor at gauss node
-            const Mat33& S = material->PK2_stress(J, C);
+            const Mat33 & S = material->PK2_stress(J, C);
 
             // Elastic forces w.r.t the gauss node applied on each nodes
             for (size_t i = 0; i < NumberOfNodesPerElement; ++i) {
-                const auto& dx = dN_dx.row(i).transpose();
+                const auto & dx = dN_dx.row(i).transpose();
                 const Vector<Dimension> f_ = (detJ * w) * F*S*dx;
                 for (size_t j = 0; j < Dimension; ++j) {
                     forces(node_indices[i],j) -= f_[j];

--- a/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
+++ b/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
@@ -152,7 +152,7 @@ void HyperelasticForcefield<Element>::addForce(
                 const auto & dx = dN_dx.row(i).transpose();
                 const Vector<Dimension> f_ = (detJ * w) * F*S*dx;
                 for (size_t j = 0; j < Dimension; ++j) {
-                    forces(node_indices[i],j) -= f_[j];
+                    forces(node_indices[i], j) -= f_[j];
                 }
             }
         }

--- a/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
+++ b/src/SofaCaribou/Forcefield/HyperelasticForcefield.inl
@@ -117,7 +117,7 @@ void HyperelasticForcefield<Element>::addForce(
     for (std::size_t element_id = 0; element_id < nb_elements; ++element_id) {
 
         // Fetch the node indices of the element
-        auto node_indices = this->topology()->domain()->element_indices(element_id);
+        const auto& node_indices = this->topology()->domain()->element_indices(element_id);
 
         // Fetch the initial and current positions of the element's nodes
         Matrix<NumberOfNodesPerElement, Dimension> current_nodes_position;
@@ -138,14 +138,14 @@ void HyperelasticForcefield<Element>::addForce(
             const auto & w = gauss_node.weight;
 
             // Deformation tensor at gauss node
-            const Mat33 F = current_nodes_position.transpose()*dN_dx;
-            const auto J = F.determinant();
+            const Mat33& F = current_nodes_position.transpose()*dN_dx;
+            const auto& J = F.determinant();
 
             // Right Cauchy-Green strain tensor at gauss node
-            const Mat33 C = F.transpose() * F;
+            const Mat33& C = F.transpose() * F;
 
             // Second Piola-Kirchhoff stress tensor at gauss node
-            const Mat33 S = material->PK2_stress(J, C);
+            const Mat33& S = material->PK2_stress(J, C);
 
             // Elastic forces w.r.t the gauss node applied on each nodes
             for (size_t i = 0; i < NumberOfNodesPerElement; ++i) {


### PR DESCRIPTION
Didn't find any pr template so I'm going freestyle.

addForce would compute elementwise nodal forces by adding them in a local structure nicely named "nodal_forces". Once this is over it would iterate over this nodal_forces structure to write in the actual sofa VecDeriv.
Thus iterating twice over each element contributions and also ignoring the mapped forces eigen vector.
` l113 Eigen::Map<Eigen::Matrix<Real, Eigen::Dynamic, Dimension, Eigen::RowMajor>> forces  (&(sofa_f[0][0]),  nb_nodes, Dimension);`

This pr removes the second loop by directly substracting the force participation of each element and uses the mapped forces vector.

While we could use the sofa WriteAccessor, the mapped force vector was already here and will be useful for the incoming pr.

Alban Odot