### PR TITLE
Fix EigenSolver template specialization export on recent version of clang

### DIFF
--- a/src/SofaCaribou/CMakeLists.txt
+++ b/src/SofaCaribou/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCE_FILES
     Ode/NewtonRaphsonSolver.cpp
     Ode/StaticODESolver.cpp
     Solver/ConjugateGradientSolver.cpp
+    Solver/EigenSolver.cpp
     Solver/LDLTSolver.cpp
     Solver/LLTSolver.cpp
     Solver/LUSolver.cpp

--- a/src/SofaCaribou/Solver/EigenSolver.cpp
+++ b/src/SofaCaribou/Solver/EigenSolver.cpp
@@ -1,0 +1,6 @@
+#include <SofaCaribou/Solver/EigenSolver.inl>
+
+namespace SofaCaribou::solver {
+template class EigenSolver<Eigen::SparseMatrix<FLOATING_POINT_TYPE, Eigen::ColMajor, int>>;
+template class EigenSolver<Eigen::SparseMatrix<FLOATING_POINT_TYPE, Eigen::RowMajor, int>>;
+}

--- a/src/SofaCaribou/Solver/EigenSolver.h
+++ b/src/SofaCaribou/Solver/EigenSolver.h
@@ -202,4 +202,7 @@ private:
     bool p_is_symmetric = false;
 };
 
+extern template class EigenSolver<Eigen::SparseMatrix<FLOATING_POINT_TYPE, Eigen::ColMajor, int>>;
+extern template class EigenSolver<Eigen::SparseMatrix<FLOATING_POINT_TYPE, Eigen::RowMajor, int>>;
+
 } // namespace SofaCaribou::solver


### PR DESCRIPTION
Seems like recent version of Clang compiler were not exporting the following EigenSolver symbols:
```c++
_SofaCaribou::solver::EigenSolver<Eigen::SparseMatrix<double, 0, int> >::GetCustomTemplateName()
_SofaCaribou::solver::EigenSolver<Eigen::SparseMatrix<double, 1, int> >::GetCustomTemplateName()
```

I think that GCC and older version of clang were exporting these automatically from the instanciation of Caribou's solver which inherits from `EigenSolver<EigenType>`, for example:
``` c++
template <class EigenSolver_t>
class LDLTSolver : public EigenSolver<typename EigenSolver_t::MatrixType> {}
// (...)
extern template class LDLTSolver<Eigen::SimplicialLDLT<Eigen::SparseMatrix<FLOATING_POINT_TYPE, Eigen::ColMajor, int>, Eigen::Lower, Eigen::AMDOrdering<int>>>
```

This PR forces the instanciation and export of the missing symbols, which seems to do the trick.

/cc @fredroy 
