### PR TITLE
Add callback mechanism to Newton-Raphson solvers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(Caribou VERSION 21.06.00)
+project(Caribou VERSION 22.06.99)
 
 # Policies
 cmake_policy(SET CMP0072 NEW)

--- a/src/SofaCaribou/Python/CMakeLists.txt
+++ b/src/SofaCaribou/Python/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
     Forcefield/HyperelasticForcefield.h
     Mass/CaribouMass.h
     Ode/LegacyStaticODESolver.h
+    Ode/NewtonRaphsonSolver.h
     Ode/StaticODESolver.h
     Solver/ConjugateGradientSolver.h
     Solver/LDLTSolver.h
@@ -22,6 +23,7 @@ set(SOURCE_FILES
     Forcefield/HyperelasticForcefield.cpp
     Mass/CaribouMass.cpp
     Ode/LegacyStaticODESolver.cpp
+    Ode/NewtonRaphsonSolver.cpp
     Ode/StaticODESolver.cpp
     Solver/ConjugateGradientSolver.cpp
     Solver/LDLTSolver.cpp
@@ -38,6 +40,7 @@ set(PYTHON_FILES
 set(PYTHON_TEST_FILES
     pytest/SofaCaribou_Forcefield_HyperelasticForcefield.py
     pytest/SofaCaribou_Mass_CaribouMass.py
+    pytest/SofaCaribou_StaticSolver.py
 )
 
 find_package(SofaPython3 REQUIRED)
@@ -64,10 +67,20 @@ caribou_add_python_module(SofaCaribou
                           )
 
 list(APPEND target_rpath
-     "$ORIGIN/../../../../../../lib"
-     "$loader_path/../../../../../../lib"
-     "$ORIGIN/../../../../lib"
-     "$loader_path/../../../../lib"
+        "$ORIGIN/../../../../../../lib"
+        "$$ORIGIN/../../../../../../lib"
+        "$loader_path/../../../../../../lib"
+        "@loader_path/../../../../../../lib"
+        "$executable_path/../../../../../../lib"
+        "@executable_path/../../../../../../lib"
+        "$ORIGIN/../../../../lib"
+        "$$ORIGIN/../../../../lib"
+        "$loader_path/../../../../lib"
+        "@loader_path/../../../../lib"
+        "$executable_path/../../../../lib"
+        "@executable_path/../../../../lib"
+        "$loader_path/../Caribou"
+        "@loader_path/../Caribou"
      )
 set_target_properties(
     ${PROJECT_NAME}
@@ -75,6 +88,10 @@ set_target_properties(
     INSTALL_RPATH "${target_rpath}"
 )
 
+
+# Make the target relocatable
+set_target_properties(${PROJECT_NAME} PROPERTIES RELOCATABLE_INSTALL_DIR "plugins/SofaCaribou")
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_PROPERTIES "RELOCATABLE_INSTALL_DIR")
 if (SOFA_VERSION VERSION_GREATER_EQUAL "20.12.99")
     # Set RPATH towards relocatable dependencies
     sofa_auto_set_target_rpath(TARGETS ${PROJECT_NAME} RELOCATABLE "plugins")

--- a/src/SofaCaribou/Python/Ode/NewtonRaphsonSolver.cpp
+++ b/src/SofaCaribou/Python/Ode/NewtonRaphsonSolver.cpp
@@ -1,0 +1,114 @@
+#include "NewtonRaphsonSolver.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#define NDEBUG
+#include <SofaCaribou/Ode/NewtonRaphsonSolver.h>
+#include <SofaCaribou/Algebra/EigenMatrix.h>
+#include <SofaCaribou/Algebra/EigenVector.h>
+
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+
+
+namespace py = pybind11;
+
+namespace SofaCaribou::ode::python {
+
+void addNewtonRaphsonSolver(pybind11::module &m) {
+    using namespace sofa::core::objectmodel;
+    py::class_<NewtonRaphsonSolver, BaseObject, sofapython3::py_shared_ptr<NewtonRaphsonSolver>> c(m, "NewtonRaphsonSolver");
+
+    py::enum_<NewtonRaphsonSolver::PatternAnalysisStrategy>(
+            c, "PatternAnalysisStrategy",
+            "Different strategies to determine when the pattern of the system matrix should be "
+            "analyzed in order to, for example, compute a permutation matrix before factorizing it.")
+    .value("ALWAYS", NewtonRaphsonSolver::PatternAnalysisStrategy::ALWAYS, "Analyze the pattern of the matrix at each Newton iterations.")
+    .value("NEVER", NewtonRaphsonSolver::PatternAnalysisStrategy::NEVER, "Never analyze the pattern of the matrix.")
+    .value("BEGINNING_OF_THE_SIMULATION", NewtonRaphsonSolver::PatternAnalysisStrategy::BEGINNING_OF_THE_SIMULATION, "Analyze the pattern of the matrix once at the beginning of the simulation.")
+    .value("BEGINNING_OF_THE_TIME_STEP", NewtonRaphsonSolver::PatternAnalysisStrategy::BEGINNING_OF_THE_TIME_STEP, "Analyze the pattern of the matrix once per time step.")
+    .export_values();
+
+    py::enum_<NewtonRaphsonSolver::Event>(
+            c, "Event",
+            "Events associated to registered callback function for different time in the NR iteration process.")
+    .value("ITERATION_BEGIN", NewtonRaphsonSolver::Event::ITERATION_BEGIN, "Event triggered at the very beginning of the Newton iteration.")
+    .value("MATRIX_ASSEMBLED", NewtonRaphsonSolver::Event::MATRIX_ASSEMBLED, "Event triggered after the system matrix has been assembled.")
+    .value("MATRIX_ANALYZED", NewtonRaphsonSolver::Event::MATRIX_ANALYZED, "Event triggered after the system matrix has been analyzed.")
+    .value("MATRIX_FACTORIZED", NewtonRaphsonSolver::Event::MATRIX_FACTORIZED, "Event triggered after the system matrix has been factorized.")
+    .value("INCREMENT_SOLVED", NewtonRaphsonSolver::Event::INCREMENT_SOLVED, "Event triggered after the system solution vector has been solved.")
+    .value("INCREMENT_PROPAGATED", NewtonRaphsonSolver::Event::INCREMENT_PROPAGATED, "Event triggered after the system solution vector has been propagated through mappings.")
+    .value("RESIDUAL_UPDATED", NewtonRaphsonSolver::Event::RESIDUAL_UPDATED, "Event triggered after the system force vector has been updated.")
+    .value("ITERATION_END", NewtonRaphsonSolver::Event::ITERATION_END, "Event triggered at the very end of the Newton iteration.")
+    .export_values();
+
+    c.def_property_readonly("iteration_times", &NewtonRaphsonSolver::iteration_times, "List of times (in nanoseconds) that each Newton-Raphson iteration took to compute in the last call to Solve().");
+    c.def_property_readonly("squared_residuals", &NewtonRaphsonSolver::squared_residuals, "The list of squared residual norms (||r||^2) of every newton iterations of the last solve call.");
+    c.def_property_readonly("squared_initial_residual", &NewtonRaphsonSolver::squared_initial_residual, "The initial squared residual (||r0||^2) of the last solve call.");
+    c.def_property("pattern_analysis_strategy", &NewtonRaphsonSolver::pattern_analysis_strategy, &NewtonRaphsonSolver::set_pattern_analysis_strategy, "Get the current strategy that determine when the pattern of the system matrix should be analyzed.");
+    c.def_property_readonly("current_iteration", &NewtonRaphsonSolver::current_iteration, "Get the current newton iteration within the time step solve call. First iteration is 1 (index starts from 1).");
+
+    c.def_property_readonly("A", [](const NewtonRaphsonSolver & solver) -> py::object {
+        if (solver.A() == nullptr) {
+            return py::none();
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenMatrix<Eigen::SparseMatrix<float, Eigen::ColMajor, int>> *>(solver.A())) {
+            return py::cast(a->matrix());
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenMatrix<Eigen::SparseMatrix<double, Eigen::ColMajor, int>> *>(solver.A())) {
+            return py::cast(a->matrix());
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenMatrix<Eigen::SparseMatrix<float, Eigen::RowMajor, int>> *>(solver.A())) {
+            return py::cast(a->matrix());
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenMatrix<Eigen::SparseMatrix<double, Eigen::RowMajor, int>> *>(solver.A())) {
+            return py::cast(a->matrix());
+        }
+
+        throw std::runtime_error("Cannot bind the system matrix type to python.");
+    }, "Complete matrix of the linearized part of system");
+
+    c.def_property_readonly("dx", [](const NewtonRaphsonSolver & solver) -> py::object {
+        if (solver.dx() == nullptr) {
+            return py::none();
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenVector<Eigen::Matrix<double, Eigen::Dynamic, 1>> *>(solver.dx())) {
+            return py::cast(a->vector());
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenVector<Eigen::Matrix<float, Eigen::Dynamic, 1>> *>(solver.dx())) {
+            return py::cast(a->vector());
+        }
+
+        throw std::runtime_error("Cannot bind the system increment vector type to python.");
+        }, "Solution of the linearized system");
+
+    c.def_property_readonly("F", [](const NewtonRaphsonSolver & solver) -> py::object {
+        if (solver.F() == nullptr) {
+            return py::none();
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenVector<Eigen::Matrix<double, Eigen::Dynamic, 1>> *>(solver.F())) {
+            return py::cast(a->vector());
+        }
+
+        if (const auto * a = dynamic_cast<const SofaCaribou::Algebra::EigenVector<Eigen::Matrix<float, Eigen::Dynamic, 1>> *>(solver.F())) {
+            return py::cast(a->vector());
+        }
+
+        throw std::runtime_error("Cannot bind the system RHS vector type to python.");
+        }, "Force vector (right-hand side) of the system");
+
+    c.def("register_callback", [](NewtonRaphsonSolver & solver, const NewtonRaphsonSolver::Event & e, py::function callback) {
+        solver.register_callback(e, [callback](const NewtonRaphsonSolver & s) {
+            callback(py::cast(s, py::return_value_policy::reference));
+        });
+    }, "Register a callback function to be called at the specific NR event (see NewtonRaphsonSolver::Event for the list of events).");
+}
+}

--- a/src/SofaCaribou/Python/Ode/NewtonRaphsonSolver.h
+++ b/src/SofaCaribou/Python/Ode/NewtonRaphsonSolver.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#undef NDEBUG
+#include <pybind11/pybind11.h>
+
+namespace SofaCaribou::ode::python {
+
+void addNewtonRaphsonSolver(pybind11::module &m);
+
+}

--- a/src/SofaCaribou/Python/Ode/StaticODESolver.cpp
+++ b/src/SofaCaribou/Python/Ode/StaticODESolver.cpp
@@ -17,10 +17,7 @@ namespace SofaCaribou::ode::python {
 
 void addStaticODESolver(py::module &m) {
     using namespace sofa::core::objectmodel;
-    py::class_<StaticODESolver, sofa::core::objectmodel::BaseObject, sofapython3::py_shared_ptr<StaticODESolver>> c (m, "StaticODESolver");
-    c.def_property_readonly("iteration_times", &StaticODESolver::iteration_times);
-    c.def_property_readonly("squared_residuals", &StaticODESolver::squared_residuals);
-    c.def_property_readonly("squared_initial_residual", &StaticODESolver::squared_initial_residual);
+    py::class_<StaticODESolver, NewtonRaphsonSolver, sofapython3::py_shared_ptr<StaticODESolver>> c (m, "StaticODESolver");
 
     sofapython3::PythonFactory::registerType<StaticODESolver>([](sofa::core::objectmodel::Base* o) {
         return py::cast(dynamic_cast<StaticODESolver*>(o));

--- a/src/SofaCaribou/Python/SofaCaribou.cpp
+++ b/src/SofaCaribou/Python/SofaCaribou.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 
 #include <SofaCaribou/Python/Ode/LegacyStaticODESolver.h>
+#include <SofaCaribou/Python/Ode/NewtonRaphsonSolver.h>
 #include <SofaCaribou/Python/Ode/StaticODESolver.h>
 #include <SofaCaribou/Python/Mass/CaribouMass.h>
 #include <SofaCaribou/Python/Forcefield/HexahedronElasticForce.h>
@@ -23,6 +24,7 @@ PYBIND11_MODULE(SofaCaribou, m) {
     SofaCaribou::topology::python::addCaribouTopology(m);
 
     // ODE bindings
+    SofaCaribou::ode::python::addNewtonRaphsonSolver(m);
     SofaCaribou::ode::python::addLegacyStaticODESolver(m);
     SofaCaribou::ode::python::addStaticODESolver(m);
 

--- a/src/SofaCaribou/Python/pytest/SofaCaribou_StaticSolver.py
+++ b/src/SofaCaribou/Python/pytest/SofaCaribou_StaticSolver.py
@@ -1,0 +1,92 @@
+import Sofa, SofaRuntime
+import sys
+import unittest
+import numpy as np
+from scipy.sparse import csr_matrix
+from pathlib import Path
+
+current_dir = Path(__file__).parent
+site_packages_dir = (current_dir / '..' / '..' / 'lib' / 'python3' / 'site-packages').resolve()
+sys.path.insert(0, str(site_packages_dir))
+print(f'Adding {site_packages_dir} to sys.path')
+
+import SofaCaribou
+from SofaCaribou import NewtonRaphsonSolver
+
+E = NewtonRaphsonSolver.Event
+
+number_of_steps = 10
+number_of_newton_iterations = 10
+threshold = 1e-15
+radius = 7.5
+length = 80
+nx = 3
+nz = 9
+eps = 1e-5
+
+
+def createScene(node):
+    node.addObject('RequiredPlugin', pluginName=[
+        'SofaBaseMechanics', 'SofaEngine', 'SofaGraphComponent', 'SofaOpenglVisual',
+        'SofaPreconditioner', 'SofaBoundaryCondition', 'SofaTopologyMapping'])
+    node.addObject('RegularGridTopology', name='grid', min=[-radius, -radius, 0], max=[radius, radius, length], n=[nx, nx, nz])
+    node.addObject('StaticODESolver', name='solver', newton_iterations=number_of_newton_iterations, correction_tolerance_threshold=1e-5, residual_tolerance_threshold=1e-5, printLog=False)
+    node.addObject('LDLTSolver', backend='Pardiso')
+    node.addObject('MechanicalObject', name='mo', position='@grid.position')
+    node.addObject('HexahedronSetTopologyContainer', name='mechanical_topology', src='@grid')
+    node.addObject('SaintVenantKirchhoffMaterial', young_modulus=3000, poisson_ratio=0.499)
+    node.addObject('HyperelasticForcefield', name='ff', topology='@mechanical_topology')
+    node.addObject('BoxROI', name='base_roi', box=[-radius - eps, -radius - eps,    0   - eps, radius + eps, radius + eps,    0   + eps])
+    node.addObject('BoxROI', name='top_roi', box=[ -radius - eps, -radius - eps, length - eps, radius + eps, radius + eps, length + eps], quad='@mechanical_topology.quads')
+    node.addObject('FixedConstraint', indices='@base_roi.indices')
+    node.addObject('QuadSetTopologyContainer', name='neumann_topology', quads='@top_roi.quadInROI')
+    node.addObject('TractionForcefield', topology='@neumann_topology', traction=[0, -30, 0], slope=0.2)
+
+
+class TestStaticSolver(unittest.TestCase):
+    def assertMatrixEqual(self, A, B):
+        return self.assertTrue(np.allclose(A.todense(), B.todense()), f"Matrices are not equal, with \nA={A} \nand\nB={B}")
+    def assertVectorAlmostEqual(self, A, B):
+        return self.assertTrue(np.allclose(A, B), f"Vectors are not equal, with \nA={A} \nand\nB={B}")
+
+    def test_residuals(self):
+        root = Sofa.Core.Node()
+        createScene(root)
+        Sofa.Simulation.init(root)
+
+        # The simulation is supposed to converged in 5 load increments. Let's check the norms of force residuals.
+        # todo(jnbrunet): These values should be validated against another external software
+        force_residuals = [
+            [1.000000000000000e+00, 4.802014099846802e-03, 3.457785823647809e-04, 6.417769508095073e-08],  # Step 1
+            [1.000000000000000e+00, 4.700052322118300e-03, 3.771851553383748e-04, 1.289757638852382e-05, 2.125041655083045e-08],  # Step 2
+            [1.000000000000000e+00, 4.416064536488316e-03, 4.703733156787435e-04, 3.659722934024732e-05, 7.791507698853802e-08],  # Step 3
+            [1.000000000000000e+00, 4.003458215116851e-03, 6.263051713537671e-04, 4.996976075176631e-05, 1.422069948624354e-07],  # Step 4
+            [1.000000000000000e+00, 3.526942203674829e-03, 8.307813177405512e-04, 4.667215114394798e-05, 1.646730071539153e-07],  # Step 5
+        ]
+
+        def increment(n): n +=1
+
+        step_number = 0
+        count = [0, 0, 0, 0, 0, 0, 0, 0]
+        root.solver.register_callback(E.ITERATION_BEGIN,   lambda s: increment(count[E.ITERATION_BEGIN]))
+        root.solver.register_callback(E.MATRIX_ASSEMBLED,  lambda s: increment(count[E.MATRIX_ASSEMBLED]))
+        root.solver.register_callback(E.MATRIX_ANALYZED,   lambda s: increment(count[E.MATRIX_ANALYZED]))
+        root.solver.register_callback(E.MATRIX_FACTORIZED, lambda s: increment(count[E.MATRIX_FACTORIZED]))
+        root.solver.register_callback(E.INCREMENT_SOLVED,  lambda s: increment(count[E.INCREMENT_SOLVED]))
+        root.solver.register_callback(E.INCREMENT_PROPAGATED, lambda s: increment(count[E.INCREMENT_PROPAGATED]))
+        root.solver.register_callback(E.RESIDUAL_UPDATED,  lambda s: increment(count[E.RESIDUAL_UPDATED]))
+        root.solver.register_callback(E.ITERATION_END,     lambda s: increment(count[E.ITERATION_END]))
+
+        for step_number in range(5):
+            Sofa.Simulation.animate(root, 1)
+            self.assertEqual(root.solver.current_iteration, len(force_residuals[step_number]), f"for step {step_number}")
+            r0 = root.solver.squared_residuals[0]
+            residuals = [np.sqrt(r/r0) for r in root.solver.squared_residuals]
+            self.assertVectorAlmostEqual(residuals, force_residuals[step_number])
+
+            self.assertEqual(count[E.ITERATION_BEGIN], root.solver.current_iteration)
+            count = [0, 0, 0, 0, 0, 0, 0, 0]
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Solvers inheriting Caribou's Newton Raphson solver class can now register callbacks at different steps of a Newton iteration.

For example, the following C++ code prints the stiffness matrix just after the latter as been assembled:
```c++
using E = SofaCaribou::ode::NewtonRaphsonSolver::Event;
using NR = SofaCaribou::ode::NewtonRaphsonSolver;

solver->register_callback(E::MATRIX_ASSEMBLED, [](const NR & solver) {
    std::cout << solver.A();
});
```

Or to get the solution vector once solved in python
```python
from SofaCaribou import NewtonRaphsonSolver
E = NewtonRaphsonSolver.Event

root.solver.register_callback(
    E.INCREMENT_SOLVED,   
    lambda s: print(s.dx())
)
```

The following events are available:
``` c++
enum class Event : unsigned int {
    /** Event triggered at the very beginning of the Newton iteration. */
    ITERATION_BEGIN = 0,

    /** Event triggered after the system matrix has been assembled. */
    MATRIX_ASSEMBLED,
 
    /** Event triggered after the system matrix has been analyzed. */
    MATRIX_ANALYZED,

    /** Event triggered after the system matrix has been factorized. */
    MATRIX_FACTORIZED,

    /** Event triggered after the system solution vector has been solved. */
    INCREMENT_SOLVED,

    /** Event triggered after the system solution vector has been propagated through mappings. */
    INCREMENT_PROPAGATED,

    /** Event triggered after the system force vector has been updated. */
    RESIDUAL_UPDATED,

    /** Event triggered at the very end of the Newton iteration. */
    ITERATION_END,
};
```