### PR TITLE
CI to keep only latest artifact

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -308,7 +308,5 @@ jobs:
           port: ${{ secrets.ARTIFACT_PORT }}
           envs: ARTIFACT_TARGET,ARTIFACT_LATEST
           script: |
-            mv $ARTIFACT_TARGET/SofaCaribou.tar.gz $ARTIFACT_TARGET.tar.gz
+            mv $ARTIFACT_TARGET/SofaCaribou.tar.gz $ARTIFACT_LATEST
             rm -rf $ARTIFACT_TARGET
-            rm -f $ARTIFACT_LATEST
-            ln -s $ARTIFACT_TARGET.tar.gz $ARTIFACT_LATEST


### PR DESCRIPTION
Artifacts were stored on my server, for example here for v20.06: https://caribou.jnbrunet.com/artifacts/linux/v20.06/

However, my server is now almost full. Therefore, starting from now, I will only keep the latest successful build on my server.